### PR TITLE
Add TAR ZSTD compression support

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     implementation "blue.endless:jankson:1.2.1"
     implementation "net.covers1624:Quack:0.4.6.69"
     implementation 'org.quartz-scheduler:quartz:2.0.2'
+    implementation "io.airlift:aircompressor:0.27"
+    implementation "org.kamranzafar:jtar:2.3"
     implementation "net.creeperhost:LevelPreview:${rootProject.preview_version}"
     implementation "net.creeperhost:LevelIO:${rootProject.levelio_version}"
 }

--- a/common/src/main/java/net/creeperhost/ftbbackups/BackupHandler.java
+++ b/common/src/main/java/net/creeperhost/ftbbackups/BackupHandler.java
@@ -116,7 +116,7 @@ public class BackupHandler {
                 FTBBackups.LOGGER.info("Skipping backup preview because preview is disabled.");
                 return "";
             }
-            
+
             long scanStart = System.currentTimeMillis();
             Path worldPath = minecraftServer.getWorldPath(LevelResource.ROOT).toAbsolutePath();
             PREVIEW.loadWorld(worldPath);
@@ -241,7 +241,7 @@ public class BackupHandler {
                         alertPlayers(minecraftServer, new TranslatableComponent(FTBBackups.MOD_ID + ".backup.starting"));
                         //Create the full path to this backup
                         Path backupPath = backupFolderPath.resolve(backupName);
-                        //Create a zip of the world folder and store it in the /backup folder
+                        //Create a backup of the world folder and store it in the /backup folder
                         List<Path> backupPaths = new LinkedList<>();
                         backupPaths.add(worldFolder);
 
@@ -311,10 +311,10 @@ public class BackupHandler {
                             }
                         }
                         backupPreview.set(createPreview(minecraftServer));
-                        if (format == Format.ZIP) {
-                            FileUtils.zip(backupPath, serverRoot, backupPaths);
-                        } else {
+                        if (format == Format.DIRECTORY) {
                             FileUtils.copy(backupPath, serverRoot, backupPaths);
+                        } else {
+                            FileUtils.compress(backupPath, serverRoot, backupPaths, format);
                         }
                         //The backup did not fail
                         backupFailed.set(false);
@@ -356,8 +356,8 @@ public class BackupHandler {
                     String sha1;
                     float ratio = 1;
                     long backupSize = FileUtils.getSize(backupLocation.toFile());
-                    if (format == Format.ZIP) {
-                        //Get the sha1 of the new backup .zip to store to the json file
+                    if (format != Format.DIRECTORY) {
+                        //Get the sha1 of the new backup .zip/.tar.zst to store to the json file
                         sha1 = FileUtils.getFileSha1(backupLocation);
                         //Do some math to figure out the ratio of compression
                         ratio = (float) backupSize / (float) FileUtils.getFolderSize(worldFolder.toFile());
@@ -400,8 +400,9 @@ public class BackupHandler {
         String date = calendar.get(Calendar.YEAR) + "-" + (calendar.get(Calendar.MONTH) + 1) + "-" + calendar.get(Calendar.DATE);
         String time = calendar.get(Calendar.HOUR_OF_DAY) + "-" + calendar.get(Calendar.MINUTE) + "-" + calendar.get(Calendar.SECOND);
         String backupName = date + "_" + time;
-        if (Config.cached().backup_format == Format.ZIP) {
-            backupName += ".zip";
+        switch (Config.cached().backup_format) {
+            case ZIP -> backupName += ".zip";
+            case ZSTD -> backupName += ".tar.zst";
         }
         return backupName;
     }
@@ -738,7 +739,7 @@ public class BackupHandler {
                 FTBBackups.LOGGER.info("File missing, removing from backups " + backup.getBackupLocation());
             }
         }
-        if (update){
+        if (update) {
             updateJson();
         }
     }

--- a/common/src/main/java/net/creeperhost/ftbbackups/config/ConfigData.java
+++ b/common/src/main/java/net/creeperhost/ftbbackups/config/ConfigData.java
@@ -73,7 +73,7 @@ public class ConfigData {
     @Comment("backup location")
     public String backup_location = ".";
 
-    @Comment("Specify the backup format. Valid options are ZIP and DIRECTORY")
+    @Comment("Specify the backup format. Valid options are ZIP, ZSTD and DIRECTORY")
     public Format backup_format = Format.ZIP;
 
     @Comment("Minimum free disk space in MB. If a backup's creation would leave less than this amount of disk space remaining, the backup will be aborted.")

--- a/common/src/main/java/net/creeperhost/ftbbackups/config/Format.java
+++ b/common/src/main/java/net/creeperhost/ftbbackups/config/Format.java
@@ -5,5 +5,6 @@ package net.creeperhost.ftbbackups.config;
  */
 public enum Format {
     ZIP,
+    ZSTD,
     DIRECTORY
 }

--- a/common/src/main/java/net/creeperhost/ftbbackups/utils/FileUtils.java
+++ b/common/src/main/java/net/creeperhost/ftbbackups/utils/FileUtils.java
@@ -3,11 +3,16 @@ package net.creeperhost.ftbbackups.utils;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+import io.airlift.compress.zstd.ZstdOutputStream;
 import net.creeperhost.ftbbackups.FTBBackups;
 import net.creeperhost.ftbbackups.config.Config;
+import net.creeperhost.ftbbackups.config.Format;
+import org.kamranzafar.jtar.TarEntry;
+import org.kamranzafar.jtar.TarOutputStream;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -54,21 +59,31 @@ public class FileUtils {
         }
     }
 
-    public static void zip(Path zipFilePath, Path serverRoot, Iterable<Path> sourcePaths) throws IOException {
+    public static void compress(Path zipFilePath, Path serverRoot, Iterable<Path> sourcePaths, Format format) throws IOException {
         Path p = Files.createFile(zipFilePath);
-        try (ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(p))) {
+        try (OutputStream f = Files.newOutputStream(p);
+             ZipOutputStream zipOut = format == Format.ZIP ? new ZipOutputStream(f) : null;
+             TarOutputStream zstdOut = format == Format.ZSTD ? new TarOutputStream(new ZstdOutputStream(f)) : null) {
             for (Path sourcePath : sourcePaths) {
                 if (!Files.isDirectory(sourcePath)) {
                     Path relFile = serverRoot.relativize(sourcePath);
                     if (matchesAny(relFile, Config.cached().excluded)) continue;
-                    packIntoZip(zs, serverRoot, sourcePath);
+                    if (format == Format.ZIP) {
+                        packIntoZip(zipOut, serverRoot, sourcePath);
+                    } else {
+                        packIntoTar(zstdOut, serverRoot, sourcePath);
+                    }
                 } else {
                     try (Stream<Path> pathStream = Files.walk(sourcePath)) {
                         for (Path path : (Iterable<Path>) pathStream::iterator) {
                             if (Files.isDirectory(path)) continue;
                             Path relFile = serverRoot.relativize(path);
                             if (matchesAny(relFile, Config.cached().excluded)) continue;
-                            packIntoZip(zs, serverRoot, path);
+                            if (format == Format.ZIP) {
+                                packIntoZip(zipOut, serverRoot, path);
+                            } else {
+                                packIntoTar(zstdOut, serverRoot, path);
+                            }
                         }
                     }
                 }
@@ -76,20 +91,27 @@ public class FileUtils {
         }
     }
 
-    private static void packIntoZip(ZipOutputStream zos, Path rootDir, Path file) throws IOException {
+    private static boolean shouldSkipPacking(Path file) {
         // Don't pack session.lock files
-        if (file.getFileName().toString().equals("session.lock")) return;
+        if (file.getFileName().toString().equals("session.lock")) return true;
         // Don't try and copy a file that does not exist
-        if (!file.toFile().exists()) return;
+        if (!file.toFile().exists()) return true;
         // Ensure files are readable
-        if (!Files.isReadable(file)) return;
+        if (!Files.isReadable(file)) return true;
+
+        return false;
+    }
+
+    private static void packIntoZip(ZipOutputStream zos, Path rootDir, Path file) throws IOException {
+        if (shouldSkipPacking(file)) return;
 
         ZipEntry zipEntry = new ZipEntry(rootDir.relativize(file).toString());
         zos.putNextEntry(zipEntry);
         updateZipEntry(zipEntry, file);
         try {
             Files.copy(file, zos);
-        } catch (Exception ignored) { }
+        } catch (Exception ignored) {
+        }
         zos.closeEntry();
     }
 
@@ -98,6 +120,27 @@ public class FileUtils {
             BasicFileAttributes basicFileAttributes = Files.readAttributes(path, BasicFileAttributes.class);
             zipEntry.setLastModifiedTime(basicFileAttributes.lastModifiedTime());
             zipEntry.setCreationTime(basicFileAttributes.creationTime());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void packIntoTar(TarOutputStream taos, Path rootDir, Path file) throws IOException {
+        if (shouldSkipPacking(file)) return;
+
+        TarEntry tarEntry = new TarEntry(file.toFile(), rootDir.relativize(file).toString());
+        taos.putNextEntry(tarEntry);
+        updateTarEntry(tarEntry, file);
+        try {
+            Files.copy(file, taos);
+        } catch (Exception ignored) {
+        }
+    }
+
+    public static void updateTarEntry(TarEntry tarEntry, Path path) {
+        try {
+            BasicFileAttributes basicFileAttributes = Files.readAttributes(path, BasicFileAttributes.class);
+            tarEntry.setModTime(basicFileAttributes.lastModifiedTime().toMillis());
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -177,8 +220,7 @@ public class FileUtils {
                     size += Files.size(path);
                 }
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             FTBBackups.LOGGER.warn("Error occurred while calculating file size", e);
         }
 

--- a/common/src/main/java/net/creeperhost/ftbbackups/utils/TieredBackupTest.java
+++ b/common/src/main/java/net/creeperhost/ftbbackups/utils/TieredBackupTest.java
@@ -53,8 +53,9 @@ public class TieredBackupTest {
         String date = calendar.get(Calendar.YEAR) + "-" + (calendar.get(Calendar.MONTH) + 1) + "-" + calendar.get(Calendar.DATE);
         String time = calendar.get(Calendar.HOUR_OF_DAY) + "-" + calendar.get(Calendar.MINUTE) + "-" + calendar.get(Calendar.SECOND);
         String s = date + "_" + time;
-        if (Config.cached().backup_format == Format.ZIP) {
-            s += ".zip";
+        switch (Config.cached().backup_format) {
+            case ZIP -> s += ".zip";
+            case ZSTD -> s += ".tar.zst";
         }
         FTBBackups.LOGGER.info("Simulating backup at time: {}, Backup Count: {}", new Date(getBackupTime()), testBackupCount);
         return s;

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     shadowLib "blue.endless:jankson:1.2.1"
     shadowLib "org.quartz-scheduler:quartz:2.0.2"
     shadowLib "net.covers1624:Quack:0.4.6.69"
+    shadowLib "io.airlift:aircompressor:0.27"
+    shadowLib "org.kamranzafar:jtar:2.3"
     shadowLib ("net.creeperhost:LevelPreview:${rootProject.preview_version}") { transitive = false }
     shadowLib ("net.creeperhost:LevelIO:${rootProject.levelio_version}") { transitive = false }
 }
@@ -56,7 +58,9 @@ shadowJar {
             'net/covers1624',
             'blue/endless',
             'de/piegames',
-            'org/quartz'
+            'org/quartz',
+            'io/airlift',
+            'org/kamranzafar'
     ]
 
     repackPackages.each {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     shadowLib ("blue.endless:jankson:1.2.1") { transitive = false }
     shadowLib ("org.quartz-scheduler:quartz:2.0.2") { transitive = false }
     shadowLib ("net.covers1624:Quack:0.4.6.69") { transitive = false }
+    shadowLib ("io.airlift:aircompressor:0.27")
+    shadowLib ("org.kamranzafar:jtar:2.3")
     shadowLib ("net.creeperhost:LevelPreview:${rootProject.preview_version}") { transitive = false }
     shadowLib ("net.creeperhost:LevelIO:${rootProject.levelio_version}") { transitive = false }
 }
@@ -61,7 +63,9 @@ shadowJar {
             'net/covers1624',
             'blue/endless',
             'de/piegames',
-            'org/quartz'
+            'org/quartz',
+            'io/airlift',
+            'org/kamranzafar'
     ]
 
     repackPackages.each {


### PR DESCRIPTION
This PR adds ZSTD algorithm (standard compression level) support for backup.

Tested on my 1.20.1 modded server. World in size of 416.6MB costs ~11 sec to compress using zip, but takes ~6 sec using ZSTD, which is a 80%~90% improvement in compression time and 20MiB more in archive size as a tradeoff.

Things I would also like to do in this PR (but need agreement):

1. Set ZSTD as default in configuration.

Some thoughts and questions:

1. I used aircompressor's pure Java implementation instead of more popular luben's zstd-jni binding. I hate embeding libs of all platforms to jar so I did this choice, and let JIT to optimize the performance. So the first backup could be mush slower, and much faster in later backups. This can be changed anyway if you disagree with me.
2. I used JTar instead of Apache Common Compress because Apache depends a lot and make the jar much fatter. It's a bad Apache culture.
3. Is shadowJar's minimization feature useful in this project? I see a lot of unused code that could be tree-shaken especially in this PR.
4. I saw the deprecated GZip code in the FileUtils.java. Should we remove that?